### PR TITLE
Added Zap support

### DIFF
--- a/facade.go
+++ b/facade.go
@@ -1,0 +1,80 @@
+package golog
+
+import (
+	"log"
+	"sync/atomic"
+)
+
+var loggerBuilder atomic.Value
+
+type baseLoggerBuilder func(prefix string, traceOn bool, printStack bool) baseLogger
+
+func setBaseLoggerBuilder(builder baseLoggerBuilder) {
+	loggerBuilder.Store(builder)
+}
+
+type loggerFacade struct {
+	prefix     string
+	traceOn    bool
+	printStack bool
+}
+
+func (lf *loggerFacade) getBaseLogger() baseLogger {
+	return loggerBuilder.Load().(baseLoggerBuilder)(lf.prefix, lf.traceOn, lf.printStack)
+}
+
+func (lf *loggerFacade) Debug(arg interface{}) {
+	lf.getBaseLogger().Debug(arg)
+}
+
+func (lf *loggerFacade) Debugf(msg string, args ...interface{}) {
+	lf.getBaseLogger().Debugf(msg, args...)
+}
+
+func (lf *loggerFacade) Debugw(msg string, keysAndValues ...interface{}) {
+	lf.getBaseLogger().Debugw(msg, keysAndValues...)
+}
+
+func (lf *loggerFacade) Error(arg interface{}) error {
+	return lf.getBaseLogger().Error(arg)
+}
+
+func (lf *loggerFacade) Errorf(msg string, args ...interface{}) error {
+	return lf.getBaseLogger().Errorf(msg, args...)
+}
+
+func (lf *loggerFacade) Errorw(msg string, keysAndValues ...interface{}) error {
+	return lf.getBaseLogger().Errorw(msg, keysAndValues...)
+}
+
+func (lf *loggerFacade) Fatal(arg interface{}) {
+	lf.getBaseLogger().Fatal(arg)
+}
+
+func (lf *loggerFacade) Fatalf(msg string, args ...interface{}) {
+	lf.getBaseLogger().Fatalf(msg, args...)
+}
+
+func (lf *loggerFacade) Fatalw(msg string, keysAndValues ...interface{}) {
+	lf.getBaseLogger().Fatalf(msg, keysAndValues...)
+}
+
+func (lf *loggerFacade) Trace(arg interface{}) {
+	lf.getBaseLogger().Trace(arg)
+}
+
+func (lf *loggerFacade) Tracef(msg string, args ...interface{}) {
+	lf.getBaseLogger().Tracef(msg, args...)
+}
+
+func (lf *loggerFacade) Tracew(msg string, keysAndValues ...interface{}) {
+	lf.getBaseLogger().Tracew(msg, keysAndValues...)
+}
+
+func (lf *loggerFacade) AsStdLogger() *log.Logger {
+	return lf.getBaseLogger().AsStdLogger()
+}
+
+func (lf *loggerFacade) IsTraceEnabled() bool {
+	return lf.traceOn
+}

--- a/facade.go
+++ b/facade.go
@@ -7,32 +7,32 @@ import (
 
 var loggerBuilder atomic.Value
 
-type baseLoggerBuilder func(prefix string, traceOn bool, printStack bool) baseLogger
+type baseLoggerBuilder func(prefix string, debugOn bool, printStack bool) baseLogger
 
 func setBaseLoggerBuilder(builder baseLoggerBuilder) {
 	loggerBuilder.Store(builder)
 }
 
 type loggerFacade struct {
-	prefix     string
-	traceOn    bool
-	printStack bool
+	prefix         string
+	isDebugEnabled bool
+	printStack     bool
 }
 
 func (lf *loggerFacade) getBaseLogger() baseLogger {
-	return loggerBuilder.Load().(baseLoggerBuilder)(lf.prefix, lf.traceOn, lf.printStack)
+	return loggerBuilder.Load().(baseLoggerBuilder)(lf.prefix, lf.isDebugEnabled, lf.printStack)
 }
 
-func (lf *loggerFacade) Debug(arg interface{}) {
-	lf.getBaseLogger().Debug(arg)
+func (lf *loggerFacade) Info(arg interface{}) {
+	lf.getBaseLogger().Info(arg)
 }
 
-func (lf *loggerFacade) Debugf(msg string, args ...interface{}) {
-	lf.getBaseLogger().Debugf(msg, args...)
+func (lf *loggerFacade) Infof(msg string, args ...interface{}) {
+	lf.getBaseLogger().Infof(msg, args...)
 }
 
-func (lf *loggerFacade) Debugw(msg string, keysAndValues ...interface{}) {
-	lf.getBaseLogger().Debugw(msg, keysAndValues...)
+func (lf *loggerFacade) Infow(msg string, keysAndValues ...interface{}) {
+	lf.getBaseLogger().Infow(msg, keysAndValues...)
 }
 
 func (lf *loggerFacade) Error(arg interface{}) error {
@@ -59,22 +59,22 @@ func (lf *loggerFacade) Fatalw(msg string, keysAndValues ...interface{}) {
 	lf.getBaseLogger().Fatalf(msg, keysAndValues...)
 }
 
-func (lf *loggerFacade) Trace(arg interface{}) {
-	lf.getBaseLogger().Trace(arg)
+func (lf *loggerFacade) Debug(arg interface{}) {
+	lf.getBaseLogger().Debug(arg)
 }
 
-func (lf *loggerFacade) Tracef(msg string, args ...interface{}) {
-	lf.getBaseLogger().Tracef(msg, args...)
+func (lf *loggerFacade) Debugf(msg string, args ...interface{}) {
+	lf.getBaseLogger().Debugf(msg, args...)
 }
 
-func (lf *loggerFacade) Tracew(msg string, keysAndValues ...interface{}) {
-	lf.getBaseLogger().Tracew(msg, keysAndValues...)
+func (lf *loggerFacade) Debugw(msg string, keysAndValues ...interface{}) {
+	lf.getBaseLogger().Debugw(msg, keysAndValues...)
 }
 
 func (lf *loggerFacade) AsStdLogger() *log.Logger {
 	return lf.getBaseLogger().AsStdLogger()
 }
 
-func (lf *loggerFacade) IsTraceEnabled() bool {
-	return lf.traceOn
+func (lf *loggerFacade) IsDebugEnabled() bool {
+	return lf.isDebugEnabled
 }

--- a/zap.go
+++ b/zap.go
@@ -1,0 +1,131 @@
+package golog
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/getlantern/errors"
+	"github.com/getlantern/hidden"
+	"github.com/getlantern/ops"
+)
+
+// ConfigureZap configures golog to use a Zap backend as configured with the given zap.Config
+func ConfigureZap(cfg zap.Config) {
+	var structuredLoggerInstances sync.Map
+	setBaseLoggerBuilder(func(prefix string, traceOn bool, printStack bool) baseLogger {
+		structuredLogger, found := structuredLoggerInstances.Load(prefix)
+		if !found {
+			stacktraceLevel := zap.ErrorLevel
+			if isStackEnabled() {
+				stacktraceLevel = zap.DebugLevel
+			}
+			// TODO: figure out how to control log level (e.g. with TRACE flag or something else)
+			logger, err := cfg.Build(zap.AddStacktrace(stacktraceLevel))
+			if err != nil {
+				fmt.Printf("Error configuring Zap logger, will use stream logger: %v\n", err)
+				structuredLogger = &streamLogger{
+					prefix:     prefix + ": ",
+					traceOn:    traceOn,
+					printStack: printStack,
+				}
+			} else {
+				structuredLogger = &zapLogger{logger.Sugar()}
+			}
+			structuredLoggerInstances.Store(prefix, structuredLogger)
+		}
+		return structuredLogger.(baseLogger)
+	})
+}
+
+type zapLogger struct {
+	*zap.SugaredLogger
+}
+
+func (l *zapLogger) Trace(arg interface{}) {
+	l.getSugaredLogger(nil).Debug(hidden.Clean(fmt.Sprint(arg)))
+}
+
+func (l *zapLogger) Tracef(template string, args ...interface{}) {
+	l.getSugaredLogger(nil).Debug(hidden.Clean(fmt.Sprintf(template, args...)))
+}
+
+func (l *zapLogger) Tracew(msg string, keysAndValues ...interface{}) {
+	l.getSugaredLogger(nil).Debugw(msg, keysAndValues...)
+}
+
+func (l *zapLogger) Debug(arg interface{}) {
+	l.getSugaredLogger(nil).Info(hidden.Clean(fmt.Sprint(arg)))
+}
+
+func (l *zapLogger) Debugf(template string, args ...interface{}) {
+	l.getSugaredLogger(nil).Infof(hidden.Clean(fmt.Sprintf(template, args...)))
+}
+
+func (l *zapLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	l.getSugaredLogger(nil).Infow(msg, keysAndValues...)
+}
+
+func (l *zapLogger) Error(arg interface{}) error {
+	err := l.getError("%v", arg)
+	l.getSugaredLogger(err).Error(hidden.Clean(fmt.Sprint(arg)))
+	return err
+}
+
+func (l *zapLogger) Errorf(template string, args ...interface{}) error {
+	err := l.getError(template, args...)
+	l.getSugaredLogger(err).Errorf(hidden.Clean(fmt.Sprintf(template, args...)))
+	return err
+}
+
+func (l *zapLogger) Errorw(msg string, keysAndValues ...interface{}) error {
+	err := l.getError(msg, keysAndValues...)
+	l.getSugaredLogger(err).Errorw(msg, keysAndValues...)
+	return err
+}
+
+func (l *zapLogger) Fatal(arg interface{}) {
+	err := l.getError("%v", arg)
+	l.getSugaredLogger(err).Fatal(hidden.Clean(fmt.Sprint(arg)))
+	fatal(err)
+}
+
+func (l *zapLogger) Fatalf(template string, args ...interface{}) {
+	err := l.getError(template, args...)
+	l.getSugaredLogger(err).Fatalf(hidden.Clean(fmt.Sprintf(template, args...)))
+	fatal(err)
+}
+
+func (l *zapLogger) Fatalw(msg string, keysAndValues ...interface{}) {
+	err := l.getError(msg, keysAndValues...)
+	l.getSugaredLogger(err).Fatalw(msg, keysAndValues...)
+	fatal(err)
+}
+
+func (l *zapLogger) AsStdLogger() *log.Logger {
+	return zap.NewStdLog(l.getSugaredLogger(nil).Desugar())
+}
+
+func (l *zapLogger) getSugaredLogger(err error) *zap.SugaredLogger {
+	sl := l.SugaredLogger
+	ctx := ops.AsMap(err, false)
+	for key, value := range ctx {
+		sl = sl.With(zap.Any(key, value))
+	}
+	return sl
+}
+
+func (l *zapLogger) getError(template string, args ...interface{}) error {
+	for _, arg := range args {
+		switch e := arg.(type) {
+		case error:
+			return e
+		}
+	}
+	return errors.NewOffset(2, template, args...)
+}
+
+type zapStdLogger struct {
+}

--- a/zap.go
+++ b/zap.go
@@ -15,7 +15,7 @@ import (
 // ConfigureZap configures golog to use a Zap backend as configured with the given zap.Config
 func ConfigureZap(cfg zap.Config) {
 	var structuredLoggerInstances sync.Map
-	setBaseLoggerBuilder(func(prefix string, traceOn bool, printStack bool) baseLogger {
+	setBaseLoggerBuilder(func(prefix string, debugOn bool, printStack bool) baseLogger {
 		structuredLogger, found := structuredLoggerInstances.Load(prefix)
 		if !found {
 			stacktraceLevel := zap.ErrorLevel
@@ -28,7 +28,7 @@ func ConfigureZap(cfg zap.Config) {
 				fmt.Printf("Error configuring Zap logger, will use stream logger: %v\n", err)
 				structuredLogger = &streamLogger{
 					prefix:     prefix + ": ",
-					traceOn:    traceOn,
+					debugOn:    debugOn,
 					printStack: printStack,
 				}
 			} else {
@@ -44,27 +44,27 @@ type zapLogger struct {
 	*zap.SugaredLogger
 }
 
-func (l *zapLogger) Trace(arg interface{}) {
+func (l *zapLogger) Debug(arg interface{}) {
 	l.getSugaredLogger(nil).Debug(hidden.Clean(fmt.Sprint(arg)))
 }
 
-func (l *zapLogger) Tracef(template string, args ...interface{}) {
+func (l *zapLogger) Debugf(template string, args ...interface{}) {
 	l.getSugaredLogger(nil).Debug(hidden.Clean(fmt.Sprintf(template, args...)))
 }
 
-func (l *zapLogger) Tracew(msg string, keysAndValues ...interface{}) {
+func (l *zapLogger) Debugw(msg string, keysAndValues ...interface{}) {
 	l.getSugaredLogger(nil).Debugw(msg, keysAndValues...)
 }
 
-func (l *zapLogger) Debug(arg interface{}) {
+func (l *zapLogger) Info(arg interface{}) {
 	l.getSugaredLogger(nil).Info(hidden.Clean(fmt.Sprint(arg)))
 }
 
-func (l *zapLogger) Debugf(template string, args ...interface{}) {
+func (l *zapLogger) Infof(template string, args ...interface{}) {
 	l.getSugaredLogger(nil).Infof(hidden.Clean(fmt.Sprintf(template, args...)))
 }
 
-func (l *zapLogger) Debugw(msg string, keysAndValues ...interface{}) {
+func (l *zapLogger) Infow(msg string, keysAndValues ...interface{}) {
 	l.getSugaredLogger(nil).Infow(msg, keysAndValues...)
 }
 

--- a/zap_test.go
+++ b/zap_test.go
@@ -1,0 +1,28 @@
+package golog
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/getlantern/errors"
+	"github.com/getlantern/ops"
+)
+
+func TestZap(t *testing.T) {
+	ConfigureZap(zap.NewProductionConfig())
+	log := LoggerFor("myprefix")
+	log.Debug("I'm starting")
+
+	parent := ops.Begin("parent").Set("a", 1)
+	defer parent.End()
+
+	err := errors.New("Failed in parent").With("b", 2)
+
+	child := ops.Begin("child").Set("b", 22).Set("c", 3)
+	defer child.End()
+
+	log.Error(err)
+	log.Errorf("%v failed: %v", "Something", err)
+	log.Errorw("It definitely failed", "error", err)
+}

--- a/zap_test.go
+++ b/zap_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestZap(t *testing.T) {
 	ConfigureZap(zap.NewProductionConfig())
-	log := LoggerFor("myprefix")
-	log.Debug("I'm starting")
+	log := NewLogger("myprefix")
+	log.Info("I'm starting")
 
 	parent := ops.Begin("parent").Set("a", 1)
 	defer parent.End()


### PR DESCRIPTION
This PR attempts to integrate Zap into golog with backward compatibility. A few notable things:

1. It maintains the existing semantics of `Trace`, `Debug`, `Error` and `Fatal`, with Trace and Debug mapping to Zap's `Debug` and `Info`.

2. It adds structured log methods like `Errorw` and supports those whether logging to Zap or the old-school stderr, stdout backend.

3. It can be configured to use either the old-school streaming backend or a Zap back-end, but the public API is the same.

4. Configuration is late-binding, so that even if you enable Zap after some package constructors have already run, subsequent log calls will go to Zap.

5. It integrates our existing ops context information with Zap so that we don't lose that information

6. I got rid of `RegisterReporter` and the `TraceOut` functionality since nothing actually seems to use those and they're hard to support with Zap

7. It maintains support for `AsStdLogger` because we actually do use this.