### PR TITLE
call T.Log in the same goroutine to avoid data race

### DIFF
--- a/testlog/testlog_test.go
+++ b/testlog/testlog_test.go
@@ -2,6 +2,7 @@ package testlog
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/getlantern/golog"
@@ -9,7 +10,7 @@ import (
 )
 
 const (
-	expectedCapture = `ERROR mytest: testlog_test.go:24 error 1
+	expectedCapture = `ERROR mytest: testlog_test.go:29 error 1
 DEBUG mytest: buffer.go:54 debug 1
 `
 )
@@ -17,6 +18,10 @@ DEBUG mytest: buffer.go:54 debug 1
 var (
 	log = golog.LoggerFor("mytest")
 )
+
+func TestMain(m *testing.M) {
+	m.Run()
+}
 
 func TestTestLog(t *testing.T) {
 	buf := &bytes.Buffer{}
@@ -28,4 +33,15 @@ func TestTestLog(t *testing.T) {
 	stop()
 	log.Debug("debug 1")
 	assert.Equal(t, expectedCapture, string(buf.Bytes()))
+}
+
+func TestConcurrent(t *testing.T) {
+	// Note: Run "go test -count 10 -run Concurrent -race"
+	golog.SetOutputs(ioutil.Discard, ioutil.Discard)
+	stop := Capture(t)
+	go func() {
+		log.Debug("something")
+	}()
+	log.Debug("something")
+	stop()
 }


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/4403