### PR TITLE
Don't bother logging to t.Log in goroutine, don't return error if log…

### DIFF
--- a/testlog/testlog.go
+++ b/testlog/testlog.go
@@ -43,6 +43,7 @@ func (w *testLogWriter) Write(p []byte) (n int, err error) {
 		_, err := os.Stderr.Write(p)
 		return len(p), err
 	}
+	w.Log(string(p))
 	return len(p), nil
 }
 

--- a/testlog/testlog_test.go
+++ b/testlog/testlog_test.go
@@ -39,9 +39,11 @@ func TestConcurrent(t *testing.T) {
 	// Note: Run "go test -count 10 -run Concurrent -race"
 	golog.SetOutputs(ioutil.Discard, ioutil.Discard)
 	stop := Capture(t)
-	go func() {
+	for i := 0; i < 100; i++ {
+		go func() {
+			log.Debug("something")
+		}()
 		log.Debug("something")
-	}()
-	log.Debug("something")
+	}
 	stop()
 }


### PR DESCRIPTION
…ging after test stopped

I tested this on my Mac with `repeat 100 go test -run Concurrent -race`  Using a high value for the `-count` flag on `go test` didn't help me reproduce the issue for some reason.

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?