### PR TITLE
Add PRINT_JSON env variable

### DIFF
--- a/golog.go
+++ b/golog.go
@@ -91,7 +91,12 @@ func GetPrepender() func(io.Writer) {
 
 // SetOutputs sets the outputs for error and debug logs to use the given Outputs.
 // Returns a function that resets outputs to their original values prior to calling SetOutputs.
+// If env variable PRINT_JSON is set, use JSON output instead of plain text
 func SetOutputs(errorOut io.Writer, debugOut io.Writer) (reset func()) {
+	if printJson, _ := strconv.ParseBool(os.Getenv("PRINT_JSON")); printJson {
+		return SetOutput(JsonOutput(errorOut, debugOut))
+	}
+
 	return SetOutput(TextOutput(errorOut, debugOut))
 }
 


### PR DESCRIPTION
Since alot of our code in flashligh is using init() function, we can't use SetOutput inside the flashlight main(), other logs are already printed before it.
So if the ENV variable is set beforehand, ALL logs will be printed correctly, thus I am adding this switch here