### PR TITLE
[logging] Add tracing linker flag

### DIFF
--- a/golog.go
+++ b/golog.go
@@ -231,6 +231,8 @@ type Logger interface {
 
 // shouldEnableTrace returns true if tracing was enforced through a linker
 // flag, or if TRACE=true is set in the environment, while favoring the former.
+//
+// See the top-level comment for more information.
 func shouldEnableTrace(currentPrefix string) bool {
 	// Linker flag checks
 	// ------------------


### PR DESCRIPTION
In Android and iOS, it's not so easy to add an environment variable. This PR adds a linker flag for trace logging so that trace logging can be included during compile time rather than runtime (through an env variable).